### PR TITLE
Update writeFile to pass string and make app executable by default on macOS

### DIFF
--- a/tools/index.ts
+++ b/tools/index.ts
@@ -103,7 +103,7 @@ export const createDistWindows = async (
 
     await promises.writeFile(
       join(dest, 'electron_version'),
-      electronVersion.major,
+      electronVersion.major.toString(),
     );
 
     await copy(

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -184,6 +184,8 @@ export const createDistMac = async (
         join(helperContentsPath, 'Info.plist'),
       ),
     ]);
+    
+    promises.chmod(join(contentsPath, 'MacOS/Electron'), 0o755) 
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
Running fails otherwise as writeFile expects a string